### PR TITLE
Pr/fix

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/OAI.pm
+++ b/lib/Dancer/Plugin/Catmandu/OAI.pm
@@ -472,9 +472,9 @@ TT
                 $cql_until = DateTime::Format::Strptime::strftime($pattern, parse_oai_datestamp($cql_until)) if $cql_until;
             }
 
-            push @cql, qq|($setting->{cql_filter})|                      if $setting->{cql_filter};
-            push @cql, qq|($set->{cql})|                                 if $set && $set->{cql};
-            push @cql, qq|($setting->{datestamp_field} >= "$cql_from")|  if $cql_from;
+            push @cql, qq|($format->{cql})| if $format->{cql};
+            push @cql, qq|($set->{cql})| if $set && $set->{cql};
+            push @cql, qq|($setting->{datestamp_field} >= "$cql_from")| if $cql_from;
             push @cql, qq|($setting->{datestamp_field} <= "$cql_until")| if $cql_until;
             unless (@cql) {
                 push @cql, "(cql.allRecords)";
@@ -595,7 +595,6 @@ register_plugin;
             limit: 200
             delimiter: ":"
             sampleIdentifier: "oai:oai.service.com:1585315"
-            cql_filter: 'status exact public'
             get_record_cql_pattern: 'id exact "%s"'
             metadata_formats:
                 -
@@ -603,6 +602,7 @@ register_plugin;
                     schema: "http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
                     metadataNamespace: "http://www.openarchives.org/OAI/2.0/oai_dc/"
                     template: views/oai_dc.tt
+                    cql: 'status exact public OR status exact deleted'
                     fix:
                       - publication_to_dc()
                 -
@@ -610,7 +610,7 @@ register_plugin;
                     schema: "http://www.loc.gov/standards/mods/v3/mods-3-0.xsd"
                     metadataNamespace: "http://www.loc.gov/mods/v3"
                     template: views/mods.tt
-                    filter: 'submissionstatus exact public'
+                    cql: 'status exact public'
                     fix:
                       - publication_to_mods()
             sets:

--- a/t/01.t
+++ b/t/01.t
@@ -1,5 +1,3 @@
-#!/usr/bin/env perl
-
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
@@ -21,6 +19,13 @@ response_content_like [GET => '/oai'], qr/illegal OAI verb/,
 
 my $res;
 $res = dancer_response("GET", '/oai', {params => {verb => "Identify" }});
-like $res->{content}, qr/request verb="Identify"/, "Identify ok";
+like $res->{content}, qr/request verb="Identify"/, "Identify";
 
-done_testing 5;
+$res = dancer_response("GET", '/oai', {params =>
+	{verb => "ListMetadataFormats"}});
+like $res->{content}, qr/request verb="ListMetadataFormats"/, "ListMetadataFormats";
+
+$res = dancer_response("GET", '/oai', {params => {verb => "ListSets"}});
+like $res->{content}, qr/setSpec>journal_article<\/setSpec/, "ListSets";
+
+done_testing;

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -15,7 +15,7 @@ __DATA__
     store: Hash
     bag: publication
     datestamp_field: date_updated
-    repositoryName: "My OAI Service Provider" 
+    repositoryName: "My OAI Service Provider"
     uri_base: "http://oai.service.com/oai"
     adminEmail: me@example.com
     earliestDatestamp: "1970-01-01T00:00:01Z"
@@ -30,7 +30,7 @@ __DATA__
             schema: "http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
             metadataNamespace: "http://www.openarchives.org/OAI/2.0/oai_dc/"
             template: views/oai_dc.tt
-            filter: 'status exact public'
+            cql: 'status exact public'
             fix:
               - nothing()
         -
@@ -38,11 +38,11 @@ __DATA__
             schema: "http://www.loc.gov/standards/mods/v3/mods-3-0.xsd"
             metadataNamespace: "http://www.loc.gov/mods/v3"
             template: views/mods.tt
-            filter: 'submissionstatus exact public'
+            cql: 'submissionstatus exact public'
             fix:
               - nothing()
     sets:
-        - 
+        -
             setSpec: openaccess
             setName: Open Access
             cql: 'oa=1'


### PR DESCRIPTION
there were some inconsistencies concerning the cql filters:
* the cql filter in the metadata_formats config had no effect
* and we had different names for the filters: cql in the sets config, filter in the formats config, and cql_filter in the overall plugin setting, very confusing... I changed it to **cql**

Let me know if more needs to be changed.