### PR TITLE
every xml answer should have content_type application/xml

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/OAI.pm
+++ b/lib/Dancer/Plugin/Catmandu/OAI.pm
@@ -64,6 +64,7 @@ sub parse_oai_datestamp {
 
 sub render {
     my ($tmpl, $data) = @_;
+    content_type 'xml';
     my $out = "";
     my $exporter = Catmandu::Exporter::Template->new(template => $tmpl, file => \$out);
     $exporter->add($data);
@@ -392,7 +393,6 @@ TT
             return render(\$template_error, $vars);
         }
 
-        content_type 'xml';
 
         if ($verb eq 'GetRecord') {
             my $id = $params->{identifier};


### PR DESCRIPTION
cf. http://localhost:5000?verb=ListIdentifiers

Delivers XML, but content-type is text/html

Solution: put "content_type 'xml'" in function "render".