### PR TITLE
Fix resumptionToken inclusion of 'until'

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/OAI.pm
+++ b/lib/Dancer/Plugin/Catmandu/OAI.pm
@@ -95,7 +95,7 @@ sub _new_token {
     $token->{_m} = $params->{metadataPrefix}
         if defined $params->{metadataPrefix};
     $token->{_f} = $from if defined $from;
-    $token->{_u} = $from if defined $until;
+    $token->{_u} = $until if defined $until;
     $token;
 }
 


### PR DESCRIPTION
Hi, noticed that resumption didn't work correctly when `until` was included in the initial ListRecords request, and found a small mistake in the code :)

I have tested the patched version at https://oai.aja.bs.no/mlnb?verb=ListRecords&metadataPrefix=marc21&from=2021-03-01&until=2021-03-17 and it seems to work fine now!