### PR TITLE
Add datestamp_index setting

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/OAI.pm
+++ b/lib/Dancer/Plugin/Catmandu/OAI.pm
@@ -162,6 +162,8 @@ sub oai_provider {
         $_[0];
         };
 
+    $setting->{datestamp_index} //= $setting->{datestamp_field};
+
     $setting->{get_record_cql_pattern} ||= $bag->id_key . ' exact "%s"';
 
     my $metadata_formats = do {
@@ -578,7 +580,7 @@ TT
                     %{$setting->{default_search_params}},
                     cql_query => $setting->{cql_filter} || 'cql.allRecords',
                     limit     => 1,
-                    sru_sortkeys => $setting->{datestamp_field},
+                    sru_sortkeys => $setting->{datestamp_index},
                 );
                 if (my $rec = $hits->first) {
                     $format_datestamp->($rec->{$setting->{datestamp_field}});
@@ -645,9 +647,9 @@ TT
             push @cql, qq|($setting->{cql_filter})| if $setting->{cql_filter};
             push @cql, qq|($format->{cql})|         if $format->{cql};
             push @cql, qq|($set->{cql})|            if $set && $set->{cql};
-            push @cql, qq|($setting->{datestamp_field} >= "$cql_from")|
+            push @cql, qq|($setting->{datestamp_index} >= "$cql_from")|
                 if $cql_from;
-            push @cql, qq|($setting->{datestamp_field} <= "$cql_until")|
+            push @cql, qq|($setting->{datestamp_index} <= "$cql_until")|
                 if $cql_until;
             unless (@cql) {
                 push @cql, "(cql.allRecords)";
@@ -875,6 +877,7 @@ The Dancer configuration file 'config.yml' contains basic information for the OA
     * store - In which Catmandu::Store are the metadata records stored
     * bag - In which Catmandu::Bag are the records of this 'store' (use: 'data' as default)
     * datestamp_field - Which field in the record contains a datestamp ('datestamp' in our example above)
+    * datestamp_index - Which CQL index should be used to find records within a specified date range (if not specified, the value from the 'datestamp_field' setting is used)
     * repositoryName - The name of the repository
     * uri_base - The full base url of the OAI controller. To be used when behind a proxy server. When not set, this module relies on the Dancer request to provide its full url. Use middleware like 'ReverseProxy' or 'Dancer::Middleware::Rebase' in that case.
     * adminEmail - An administrative email. Can be string or array of strings. This will be included in the Identify response.


### PR DESCRIPTION
This allows for the CQL index name to be different from the field name in the store.

Example:

```
plugins:
  'Catmandu::OAI':
    store: es_store
    bag: some_bag
    datestamp_field: modified
    datestamp_index: rec.modified
```

